### PR TITLE
Add index and columns validators and integrate them into DataFrameValidator

### DIFF
--- a/pandas_validator/__init__.py
+++ b/pandas_validator/__init__.py
@@ -16,4 +16,8 @@ from .validators.columns import (
 from .validators.dataframe import (
     DataFrameValidator,
 )
-
+from .validators.index import (
+    BaseIndexValidator,
+    IndexValidator,
+    ColumnsValidator,
+)

--- a/pandas_validator/validators/dataframe.py
+++ b/pandas_validator/validators/dataframe.py
@@ -1,15 +1,27 @@
 from .columns import ColumnValidatorMixin
+from .index import IndexValidator, ColumnsValidator
 from ..core.exceptions import ValidationError
 
 
 class DataFrameValidator(object):
+    index = None
+    columns = None
+
     column_num = None  # int The number of column.
     row_num = None  # int The number of row.
 
     def __init__(self):
-        pass
+        self._setup_index_and_columns_validator()
+
+    def _setup_index_and_columns_validator(self):
+        if self.row_num is not None and self.index is None:
+            self.index = IndexValidator(size=self.row_num)
+
+        if self.column_num is not None and self.columns is None:
+            self.columns = ColumnsValidator(size=self.column_num)
 
     def validate(self, df):
+        self._run_index_and_columns_validator(df)
         self._run_column_validator(df)
         self._check_dataframe_size(df)
 
@@ -20,6 +32,15 @@ class DataFrameValidator(object):
 
         for v in column_validators:
             v.validate(df)
+        return True
+
+    def _run_index_and_columns_validator(self, df):
+        if self.index is not None:
+            self.index.validate(df.index)
+
+        if self.columns is not None:
+            self.columns.validate(df.columns)
+
         return True
 
     def _check_dataframe_size(self, df):

--- a/pandas_validator/validators/index.py
+++ b/pandas_validator/validators/index.py
@@ -1,0 +1,35 @@
+from ..core.exceptions import ValidationError
+
+
+class BaseIndexValidator(object):
+    def __init__(self, size=None, type=None):
+        self.size = size
+        self.type = type
+
+    def validate(self, index):
+        self._check_size(index)
+        self._check_type(index)
+
+    def _check_size(self, index):
+        if self.size is not None and index.size != self.size:
+            raise ValidationError('Index has the different size.')
+
+    def _check_type(self, index):
+        if self.type is not None and index.dtype.type != self.type:
+            raise ValidationError('Index has the different type.')
+
+    def is_valid(self, index):
+        try:
+            self.validate(index)
+        except ValidationError:
+            return False
+        else:
+            return True
+
+
+class IndexValidator(BaseIndexValidator):
+    pass
+
+
+class ColumnsValidator(BaseIndexValidator):
+    pass

--- a/pandas_validator/validators/test/test_dataframe.py
+++ b/pandas_validator/validators/test/test_dataframe.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import pandas as pd
+import numpy as np
 
 import pandas_validator as pv
 from pandas_validator.core.exceptions import ValidationError
@@ -46,4 +47,50 @@ class DataFrameValidatorSizeTest(TestCase):
 
     def test_invalid_when_not_matches_column_numbers(self):
         df = pd.DataFrame({'x': [0, 1, 2], 'y': [1., 2., 3.], 'z': [1, 2, 3]})
+        self.assertRaises(ValidationError, self.validator.validate, df)
+
+
+class DataFrameValidatorFixtureWithIndex(pv.DataFrameValidator):
+    """Fixture for testing the validation of index validator."""
+    index = pv.IndexValidator(size=3, type=np.int64)
+
+
+class DataFrameValidatorIndexTest(TestCase):
+    """Testing the validation of index size and type."""
+    def setUp(self):
+        self.validator = DataFrameValidatorFixtureWithIndex()
+
+    def test_valid_when_matches_index_size_and_type(self):
+        df = pd.DataFrame([0, 1, 2])
+        self.assertIsNone(self.validator.validate(df))
+
+    def test_invalid_when_not_matches_index_size(self):
+        df = pd.DataFrame([0, 1, 2, 3])
+        self.assertRaises(ValidationError, self.validator.validate, df)
+
+    def test_invalid_when_not_matches_index_type(self):
+        df = pd.DataFrame([0, 1, 2], index=['a', 'b', 'c'])
+        self.assertRaises(ValidationError, self.validator.validate, df)
+
+
+class DataFrameValidatorFixtureWithColumns(pv.DataFrameValidator):
+    """Fixture for testing the validation of columns validator."""
+    columns = pv.ColumnsValidator(size=2, type=np.object_)
+
+
+class DataFrameValidatorColumnsIndexTest(TestCase):
+    """Testing the validation of columns size and type"""
+    def setUp(self):
+        self.validator = DataFrameValidatorFixtureWithColumns()
+
+    def test_valid_when_matches_columns_size_and_type(self):
+        df = pd.DataFrame({'x': [0, 1, 2], 'y': [1., 2., 3.]})
+        self.assertIsNone(self.validator.validate(df))
+
+    def test_invalid_when_not_matches_columns_size(self):
+        df = pd.DataFrame({'x': [0, 1, 2], 'y': [1., 2., 3.], 'z': [1, 2, 3]})
+        self.assertRaises(ValidationError, self.validator.validate, df)
+
+    def test_invalid_when_not_matches_columns_type(self):
+        df = pd.DataFrame([[0, 1, 2], [1., 2., 3.]])
         self.assertRaises(ValidationError, self.validator.validate, df)

--- a/pandas_validator/validators/test/test_index.py
+++ b/pandas_validator/validators/test/test_index.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+import pandas as pd
+import numpy as np
+
+import pandas_validator as pv
+from pandas_validator.core.exceptions import ValidationError
+
+
+class BaseIndexValidatorTest(TestCase):
+    def setUp(self):
+        self.validator = pv.BaseIndexValidator(size=3, type=np.int64)
+
+    def test_is_valid_when_size_and_type_are_ok(self):
+        index = pd.Index([0, 1, 2])
+        self.assertIsNone(self.validator.validate(index))
+
+    def test_is_invalid_when_size_is_not_ok(self):
+        index = pd.Index([0, 1, 2, 3])
+        self.assertRaises(ValidationError, self.validator.validate, index)
+
+    def test_is_invalid_when_type_is_not_ok(self):
+        index = pd.Index(['a', 'b', 'c'])
+        self.assertRaises(ValidationError, self.validator.validate, index)


### PR DESCRIPTION
## In short
- Implement validation of **types** of index and column of DataFrame, in addtion to their sizes
- Current `row_num` and `column_num` still work (they now use new validators inside).
## In detail

The current implementation offers only validations of number of rows or columns of DataFrame but not type of them.

For example, we cannot check index type of DataFrame:

``` python
class SampleDataFrameValidator(DataFrameValidator):
    row_num = 3

validator = SampleDataFrameValidator()

df = pd.DataFrame([0, 1, 2])
validator.is_valid(df)  # True.

df = pd.DataFrame([0, 1, 2, 3])
validator.is_valid(df)  # False.

df = pd.DataFrame([0, 1, 2], index=['a', 'b', 'c'])
# We want to check if the index type is np.int16 or not but there is no way to do it...
```

This pull request implements `IndexValidator` and `ColumnValidator`, which can be used for validation of types of index and columns of DataFrame.

For example, we can now check index type like this:

``` python
class SampleDataFrameValidator(DataFrameValidator):
    index = IndexValidator(size=3, type=np.int64)

validator = SampleDataFrameValidator()

df = pd.DataFrame([0, 1, 2])
validator.is_valid(df)  # True.

df = pd.DataFrame([0, 1, 2, 3])
validator.is_valid(df)  # False.

df = pd.DataFrame([0, 1, 2], index=['a', 'b', 'c'])
validator.is_valid(df)  # False.
```
