### PR TITLE
Add possibility to check values to index validator

### DIFF
--- a/pandas_validator/validators/index.py
+++ b/pandas_validator/validators/index.py
@@ -1,14 +1,24 @@
+import pandas as pd
 from ..core.exceptions import ValidationError
 
 
 class BaseIndexValidator(object):
-    def __init__(self, size=None, type=None):
+    def __init__(self, size=None, type=None, values=None):
+
+        if values is not None and size is None:
+            size = len(values)
+
+        if values is not None and type is None:
+            type = pd.Index(values).dtype
+
         self.size = size
         self.type = type
+        self.values = values
 
     def validate(self, index):
         self._check_size(index)
         self._check_type(index)
+        self._check_values(index)
 
     def _check_size(self, index):
         if self.size is not None and index.size != self.size:
@@ -17,6 +27,10 @@ class BaseIndexValidator(object):
     def _check_type(self, index):
         if self.type is not None and index.dtype.type != self.type:
             raise ValidationError('Index has the different type.')
+
+    def _check_values(self, index):
+        if self.values is not None and not (index == self.values).all():
+            raise ValidationError('Index has different values')
 
     def is_valid(self, index):
         try:
@@ -33,3 +47,4 @@ class IndexValidator(BaseIndexValidator):
 
 class ColumnsValidator(BaseIndexValidator):
     pass
+

--- a/pandas_validator/validators/test/test_dataframe.py
+++ b/pandas_validator/validators/test/test_dataframe.py
@@ -93,3 +93,23 @@ class DataFrameValidatorColumnsIndexTest(TestCase):
     def test_invalid_when_not_matches_columns_type(self):
         df = pd.DataFrame([[0, 1, 2], [1., 2., 3.]])
         self.assertFalse(self.validator.is_valid(df))
+
+
+class DataFrameValidatorFixtureWithColumnValues(pv.DataFrameValidator):
+    """Fixture for testing the validation of columns validator with values"""
+    columns = pv.ColumnsValidator(values=['x', 'y'])
+
+
+class DataFrameValidatorColumnsWithValuesTest(TestCase):
+    """Testing the validation of columns with values"""
+
+    def setUp(self):
+        self.validator = DataFrameValidatorFixtureWithColumnValues()
+
+    def test_valid_when_values_match(self,):
+        df = pd.DataFrame({'x': [0, 1, 2], 'y': [1., 2., 3.]})
+        self.assertTrue(self.validator.is_valid(df))
+
+    def test_invalid_when_values_do_not_match(self, ):
+        df = pd.DataFrame({'one': [0, 1, 2], 'two': [1., 2., 3.]})
+        self.assertFalse(self.validator.is_valid(df))

--- a/pandas_validator/validators/test/test_index.py
+++ b/pandas_validator/validators/test/test_index.py
@@ -21,3 +21,17 @@ class BaseIndexValidatorTest(TestCase):
     def test_is_invalid_when_type_is_not_ok(self):
         index = pd.Index(['a', 'b', 'c'])
         self.assertRaises(ValidationError, self.validator.validate, index)
+
+
+class BaseIndexValidatorValuesTest(TestCase):
+
+    def setUp(self):
+        self.validator = pv.BaseIndexValidator(values=['one', 'two'])
+
+    def test_is_valid_when_values_are_ok(self):
+        index = pd.Index(['one', 'two'])
+        self.assertIsNone(self.validator.validate(index))
+
+    def test_is_invalid_when_values_are_not_ok(self):
+        index = pd.Index([1, 2])
+        self.assertRaises(ValidationError, self.validator.validate, index)


### PR DESCRIPTION
Sometimes we want to validate that a ```DataFrame``` contains certain columns, without necessarily worrying about what is the content of that column.

In my case I am parsing a file as part of an ETL process and want to check the result. My expectation is that the file will always have the same columns in the same place. Say the columns I am expecting are ```['a', 'b']```, then

```python
pd.DataFrame(
    [
        [1, 2], 
        [3, 4],
    ],
    columns=['a', 'b'],
)
```

would be valid, while both 
```python
pd.DataFrame(
    [
        [2, 1], 
        [4, 3],
    ],
    columns=['b', 'a'],
)
```
and
```python
pd.DataFrame(
    [
        [1, 2], 
        [3, 4],
    ],
    columns=['x', 'y'],
)
```

would not be valid. This case is very strict (i.e. order of columns matters) and we might want to relax this in future iterations.
